### PR TITLE
Switch to default git-pile branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         repository: git-pile/git-pile
         path: git-pile
-        ref: tip
 
     - name: Install git-pile
       uses: git-pile/automation/env-setup@main


### PR DESCRIPTION
Everything should now be merged in git-pile, switch to the default
branch.

Signed-off-by: Lucas De Marchi <lucas.demarchi@intel.com>